### PR TITLE
Automatically profile newly spawned threads

### DIFF
--- a/perfsephone/perfetto_renderer.py
+++ b/perfsephone/perfetto_renderer.py
@@ -68,7 +68,7 @@ def remove_pytest_related_frames(root_frame: Frame) -> Sequence[Frame]:
     return [root_frame]
 
 
-def render(session: Session, start_time: float) -> List[SerializableEvent]:
+def render(session: Session, start_time: float, tid: int = 1) -> List[SerializableEvent]:
     renderer = SpeedscopeRenderer()
     root_frame = session.root_frame()
     if root_frame is None:
@@ -103,13 +103,14 @@ def render(session: Session, start_time: float) -> List[SerializableEvent]:
                         cat=Category("runtime"),
                         ts=timestamp,
                         args={"file": file or "", "line": str(line or 0), "name": name or ""},
+                        tid=tid,
                     )
                 )
             elif (
                 speedscope_event.type == SpeedscopeEventType.CLOSE
                 and name not in SYNTHETIC_LEAF_IDENTIFIERS
             ):
-                result.append(EndDurationEvent(ts=timestamp))
+                result.append(EndDurationEvent(ts=timestamp, tid=tid))
         return result
 
     for root in new_roots:

--- a/perfsephone/plugin.py
+++ b/perfsephone/plugin.py
@@ -225,8 +225,6 @@ class PytestPerfettoPlugin:
     def pytest_pyfunc_call(self, pyfuncitem: pytest.Function) -> Generator[None, None, None]:
         is_async = inspect.iscoroutinefunction(pyfuncitem.function)
 
-        profiler = ThreadProfiler()
-
         with self.__profile(root_frame_name="call", is_async=is_async) as events:
             yield
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,6 @@
+import json
 from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -36,3 +38,40 @@ def test_given_non_serializable_params__when_dump_trace__then_file_is_written(
     result = pytester.runpytest_subprocess(f"--perfetto={temp_perfetto_file_path}")
     result.assert_outcomes(passed=1)
     assert temp_perfetto_file_path.exists()
+
+
+def test_given_multiple_threads__then_multiple_distinct_tids_are_reported(
+    pytester: pytest.Pytester, temp_perfetto_file_path: Path
+) -> None:
+    pytester.makepyfile("""
+        import threading
+        import time
+
+        SLEEP_TIME_S = 0.002
+
+        def test_hello() -> None:
+            def foo() -> None:
+                def bar() -> None:
+                    time.sleep(SLEEP_TIME_S)
+                thread = threading.Thread(target=bar)
+                thread.start()
+                thread.join()
+
+            thread = threading.Thread(target=foo)
+            thread.start()
+            thread.join()
+    """)
+    pytester.runpytest_subprocess(f"--perfetto={temp_perfetto_file_path}").assert_outcomes(passed=1)
+    trace_file = json.load(temp_perfetto_file_path.open("r"))
+    EXPECTED_DISTINCT_TID_COUNT: Final[int] = 3
+
+    assert (
+        len(
+            {
+                event["tid"]
+                for event in trace_file
+                if event.get("name", "") in ["foo", "bar", "test_hello"]
+            }
+        )
+        == EXPECTED_DISTINCT_TID_COUNT
+    )


### PR DESCRIPTION
This PR implements #10. 

The implementation makes use of a hack where `sys.settrace` is (ab)used detect the start and end of the execution of threads. Since the pyinstrument profiler requires active profilers to be stopped in the same thread that started them, we needed to stop the profiler inside of `sys.settrace` once we have detected that the thread being profiled has finished executing its target.

Hopefully, pyinstrument will natively support profiling multiple threads in the near future, allowing us to get rid of this `sys.settrace` hack. There seems to be an [issue](https://github.com/joerick/pyinstrument/issues/352) in pyinstrument's issue board tracking this feature, but the issue (and the repo itself) seems pretty inactive. 