### PR TITLE
Fix threading feature

### DIFF
--- a/perfsephone/perfetto_renderer.py
+++ b/perfsephone/perfetto_renderer.py
@@ -66,7 +66,10 @@ def remove_pytest_related_frames(root_frame: Frame) -> Sequence[Frame]:
     return [root_frame]
 
 
-def render(session: Session, start_time: float, tid: int = 1) -> TraceStore:
+def render(session: Session, start_time: Optional[float] = None, tid: int = 1) -> TraceStore:
+    if start_time is None:
+        start_time = session.start_time
+
     renderer = SpeedscopeRenderer()
     root_frame = session.root_frame()
     if root_frame is None:

--- a/perfsephone/plugin.py
+++ b/perfsephone/plugin.py
@@ -25,7 +25,6 @@ from perfsephone import (
     InstantScope,
     Timestamp,
 )
-from perfsephone.perfetto_renderer import render
 from perfsephone.profiler import Profiler
 from perfsephone.trace_store import ChromeTraceEventFormatJSONStore, TraceStore
 
@@ -53,17 +52,7 @@ class PytestPerfettoPlugin:
     def pytest_sessionfinish(self, session: pytest.Session) -> Generator[None, None, None]:
         # Called after whole test run finished, right before returning the exit status to the system
         # https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_sessionfinish
-        self.profiler.unregister_thread_profiler()
-
-        for index, profiler_session in enumerate(
-            self.profiler.thread_profiler.drain(), start=self.profiler.max_tid + 1
-        ):
-            self.events.merge(
-                render(
-                    session=profiler_session,
-                    tid=index,
-                )
-            )
+        self.profiler.unregister_thread_profiler(self.events)
 
         self.events.add_end_event()
         perfetto_path: Union[Path, Notset] = session.config.getoption("perfetto_path")

--- a/perfsephone/plugin.py
+++ b/perfsephone/plugin.py
@@ -61,7 +61,6 @@ class PytestPerfettoPlugin:
             self.events.merge(
                 render(
                     session=profiler_session,
-                    start_time=profiler_session.start_time,
                     tid=index,
                 )
             )

--- a/perfsephone/profiler.py
+++ b/perfsephone/profiler.py
@@ -3,7 +3,7 @@ import threading
 from contextlib import contextmanager
 from itertools import chain
 from types import FrameType
-from typing import Any, Dict, Generator, Literal, Optional, Sequence, Union
+from typing import Any, Dict, Generator, List, Literal, Optional, Sequence, Union
 
 import pyinstrument
 
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class _ThreadProfiler:
     def __init__(self) -> None:
         self.thread_local = threading.local()
-        self.profilers: Dict[int, pyinstrument.Profiler] = {}
+        self.profilers: List[pyinstrument.Profiler] = []
 
     def __call__(
         self,
@@ -55,7 +55,7 @@ class _ThreadProfiler:
                     self.thread_local, "profiler"
                 ), "because a profiler must have been started"
                 self.thread_local.profiler.stop()
-                self.profilers[threading.get_ident()] = self.thread_local.profiler
+                self.profilers.append(self.thread_local.profiler)
 
 
 class Profiler:
@@ -103,7 +103,7 @@ class Profiler:
 
         profiles_to_render = (
             profile
-            for profile in chain([profile], thread_profiler.profilers.values())
+            for profile in chain([profile], thread_profiler.profilers)
             if profile.last_session
         )
 

--- a/perfsephone/profiler.py
+++ b/perfsephone/profiler.py
@@ -128,7 +128,6 @@ class Profiler:
             result.merge(
                 render(
                     session=session,
-                    start_time=session.start_time,
                     tid=index,
                 )
             )

--- a/perfsephone/profiler.py
+++ b/perfsephone/profiler.py
@@ -83,8 +83,20 @@ class Profiler:
     def register_thread_profiler(self) -> None:
         self.thread_profiler.register()
 
-    def unregister_thread_profiler(self) -> None:
+    def unregister_thread_profiler(self, trace_store: TraceStore) -> None:
+        """Stop profiling non-main threads. The profile of each thread which has not yet been
+        rendered will be merged in the provided trace store"""
         self.thread_profiler.unregister()
+
+        for index, profiler_session in enumerate(
+            self.thread_profiler.drain(), start=self.max_tid + 1
+        ):
+            trace_store.merge(
+                render(
+                    session=profiler_session,
+                    tid=index,
+                )
+            )
 
     @contextmanager
     def __call__(


### PR DESCRIPTION
A number of bugs are fixed in this PR:
* Stop correlating profilers with threads ids. It turns out that in fastapi, for some reason, the same thread would repeatedly have `Thread.run` called with the same thread id, causing profilers to overwrite each other, losing the profiler data from previous test runs;
* Start the the thread profiler at the start of the pytest session, before any tests have had the chance to start executing their setup, and stop the thread profiler at the end of the pytest session. This allows us to capture & profile threads which are created during test setup or tear down. By ignoring threads created in setup, functions submitted to thread pools which were created in fixtures would not be traced. 